### PR TITLE
Bump base image to 0.0.4 and tidy Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM public.ecr.aws/n8h5y2v5/rad-security/rad-image-scanner:0.0.3
+FROM public.ecr.aws/n8h5y2v5/rad-security/rad-image-scanner:0.0.4
 
 # The base image already has grype and rad-image-scanner. We only need the
 # tiny entrypoint shell that translates Action inputs into CLI flags.
-USER root
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary

- Bump \`FROM public.ecr.aws/n8h5y2v5/rad-security/rad-image-scanner\` from \`0.0.3\` to \`0.0.4\`. The new image is built on \`alpine:3.20\` instead of inheriting \`anchore/grype\`'s \`FROM scratch\` (see rad-security/image-scanner#4), which gives downstream consumers \`/etc/passwd\`, \`/bin/sh\`, and \`chmod\`.
- Drop \`USER root\` — GitHub container actions run as root by default.
- Fold \`RUN chmod +x\` into \`COPY --chmod=755\` so the Dockerfile is one layer shorter.

Fixes the build error seen in \`ksoc-private/plugin-ksoc-sbom#287\`:

\`\`\`
> [3/3] RUN chmod +x /entrypoint.sh
process did not complete successfully: unable to find user root: invalid argument
\`\`\`

## Test plan

- [ ] **Wait for \`rad-image-scanner:0.0.4\` to be published to public ECR** before merging — \`0.0.4\` doesn't exist yet, will be cut after rad-security/image-scanner#4 merges.
- [ ] Once \`0.0.4\` is live, re-run CI on this PR and confirm the image builds (no \`USER root\` / \`chmod\` failures).
- [ ] Re-run \`ksoc-private/plugin-ksoc-sbom#287\` against the new action tag and confirm the scan step completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)